### PR TITLE
30 partager une offre publiquement

### DIFF
--- a/frontend/src/commons/ShareDialog/ContactPublic.js
+++ b/frontend/src/commons/ShareDialog/ContactPublic.js
@@ -1,0 +1,72 @@
+import React, { useCallback, useState } from 'react';
+import { makeStyles, Avatar, Switch, ListItem, ListItemAvatar, ListItemText } from '@material-ui/core';
+import PublicIcon from '@material-ui/icons/Public';
+
+const useStyles = makeStyles((theme) => ({
+  listItem: {
+    paddingLeft: 0,
+    paddingRight: 0,
+    paddingTop: 12,
+    paddingBottom: 12,
+    marginBottom: 4,
+    borderBottom: '1px solid grey'
+  },
+  primaryText: {
+    width: '30%',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    flexBasis: '100%',
+  },
+  secondaryText: {
+    textAlign: 'center',
+    width: '60%',
+    fontStyle: 'italic',
+    color: 'grey',
+  },
+  avatarItem: {
+    minWidth: 50,
+  },
+  avatar: {
+    backgroundImage: `radial-gradient(circle at 50% 3em, ${theme.palette.primary.light} 0%, ${theme.palette.primary.main} 100%)`,
+  },
+}));
+
+const ContactPublic = ({ record, editPublicSetting, isPublic }) => {
+  const classes = useStyles();
+
+  const [viewChecked, setViewChecked] = useState(isPublic);
+
+  const switchView = useCallback(() => {
+    if (!viewChecked) {
+      setViewChecked(true);
+      editPublicSetting({action:'add'});
+    } else {
+      setViewChecked(false);
+      editPublicSetting({action:'remove'});
+    }
+  }, [viewChecked, setViewChecked, editPublicSetting]);
+
+  return (
+    <ListItem className={classes.listItem}>
+      <ListItemAvatar className={classes.avatarItem}>
+        <Avatar src="" className={classes.avatar}>
+        <PublicIcon />
+        </Avatar>
+      </ListItemAvatar>
+      <ListItemText
+        className={classes.primaryText}
+        primary="Rendre l'offre publique"
+      />
+      <ListItemText
+        className={classes.secondaryText}
+        secondary={<Switch size="small" checked={viewChecked} onChange={switchView} />}
+      />
+      <ListItemText
+        className={classes.secondaryText}
+      />
+    </ListItem>
+  );
+};
+
+export default ContactPublic;

--- a/frontend/src/commons/ShareDialog/ContactsShareList.js
+++ b/frontend/src/commons/ShareDialog/ContactsShareList.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { List, makeStyles, Box, CircularProgress } from '@material-ui/core';
 import ContactItem from './ContactItem';
+import ContactPublic from './ContactPublic';
 import { useListContext } from 'react-admin';
 import Alert from '@material-ui/lab/Alert';
 
@@ -13,11 +14,17 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const ContactsShareList = ({ addInvitation, removeInvitation, announces, announcers, isOrganizer }) => {
+const ContactsShareList = ({ addInvitation, removeInvitation, editPublicSetting, announces, announcers, isOrganizer, isPublic }) => {
   const classes = useStyles();
   const { ids, data, loading, ...rest } = useListContext();
   return (
     <List dense className={classes.list}>
+      <ContactPublic
+        key="public"
+        editPublicSetting={editPublicSetting}
+        isPublic={isPublic}
+        {...rest}
+      />
       {ids.map((id, i) => (
         <ContactItem
           key={i}

--- a/frontend/src/commons/lists/CardItem.js
+++ b/frontend/src/commons/lists/CardItem.js
@@ -1,0 +1,112 @@
+import React, { useMemo } from 'react';
+import { linkToRecord, Link, DateField } from 'react-admin';
+import { Box, Card, CardMedia, CardContent, makeStyles } from '@material-ui/core';
+import PublicIcon from '@material-ui/icons/Public';
+import { useAgents } from '@semapps/auth-provider';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    // marginTop: 5,
+  },
+  details: {
+    display: 'flex',
+    marginBottom: 15,
+    [theme.breakpoints.down('xs')]: {
+      flexDirection: 'column',
+    },
+  },
+  image: {
+    width: 180,
+    minWidth: 180,
+    minHeight: 145,
+    backgroundColor: theme.palette.grey['300'],
+    [theme.breakpoints.down('xs')]: {
+      width: '100%',
+    },
+  },
+  date: {
+    width: 180,
+    minWidth: 180,
+    minHeight: 145,
+    backgroundImage: `radial-gradient(circle at 50% 14em, ${theme.palette.primary.light} 0%, ${theme.palette.primary.main} 100%)`,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    [theme.breakpoints.down('xs')]: {
+      width: '100%',
+    },
+    padding: 0,
+    color: 'white',
+  },
+  day: {
+    fontSize: 50,
+    lineHeight: 1.3,
+  },
+  content: {
+    flex: '1 0 auto',
+    flexShrink: 1,
+    paddingTop: 10,
+    paddingBottom: '16px !important',
+    [theme.breakpoints.down('xs')]: {
+      padding: 10,
+    },
+  },
+  publicIconContainer: {
+    position: 'relative'
+  },
+  publicIcon: {
+    position: 'absolute',
+    top: 8,
+    right: 8,
+    backgroundColor: theme.palette.primary.main,
+    color: theme.palette.primary.contrastText,
+    borderRadius: '50%'
+  }
+}));
+
+const CardItem = ({ record, CardComponent, link }) => {
+  const classes = useStyles();
+  const { agents } = useAgents(record.id);
+  const basePath = useMemo(() => record.type.endsWith('Offer') ? '/offers' : '/projects', [record]);
+  const image = useMemo(() => record['pair:depictedBy'], [record]);
+  const isPublic = useMemo(() => agents["foaf:Agent"]?.permissions.includes('acl:Read'), [agents]);
+  return (
+    <Link key={record.id} to={linkToRecord(basePath, record.id, link)} className={classes.root}>
+      <Card key={record.id} className={classes.details}>
+        {image ? (
+          <CardMedia className={classes.image} image={Array.isArray(image) ? image[0] : image} />
+        ) : (
+          <CardContent className={classes.date}>
+            <DateField record={record} variant="subtitle1" source="dc:created" locales={process.env.REACT_APP_LANG} options={{ weekday: 'long' }} />
+            <DateField
+              record={record}
+              variant="h4"
+              source="dc:created"
+              locales={process.env.REACT_APP_LANG}
+              options={{ day: 'numeric' }}
+              className={classes.day}
+            />
+            <DateField record={record} variant="subtitle1" source="dc:created" locales={process.env.REACT_APP_LANG} options={{ month: 'long' }} />
+          </CardContent>
+        )}
+        <CardContent className={classes.content}>
+          <CardComponent record={record} />
+        </CardContent>
+        { isPublic &&
+          <Box className={classes.publicIconContainer}>
+            <PublicIcon className={classes.publicIcon} titleAccess="Offre publique" />
+          </Box>
+        }
+      </Card>
+    </Link>
+  );
+};
+
+CardItem.defaultProps = {
+  link: 'show',
+};
+
+export default CardItem;

--- a/frontend/src/commons/lists/CardsList.js
+++ b/frontend/src/commons/lists/CardsList.js
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { useMemo } from 'react';
 import { useListContext, linkToRecord, Link, DateField } from 'react-admin';
 import { Card, CardMedia, CardContent, makeStyles, Box, CircularProgress } from '@material-ui/core';
 
@@ -56,10 +56,11 @@ const useStyles = makeStyles((theme) => ({
 
 const CardsList = ({ CardComponent, link, setLoaded }) => {
   const classes = useStyles();
-  const { ids, data, loading, loaded } = useListContext();
+  const { data, loading, loaded } = useListContext();
   if (loaded && setLoaded) {
     setLoaded();
   }
+  const ids = useMemo(() => Object.values(data).map(d => d.id), [data]);
   return loading ? (
     <Box display="flex" justifyContent="center" alignItems="center">
       <CircularProgress color="secondary" />

--- a/frontend/src/commons/lists/CardsList.js
+++ b/frontend/src/commons/lists/CardsList.js
@@ -1,61 +1,9 @@
 import React, { useMemo } from 'react';
-import { useListContext, linkToRecord, Link, DateField } from 'react-admin';
-import { Card, CardMedia, CardContent, makeStyles, Box, CircularProgress } from '@material-ui/core';
-
-const useStyles = makeStyles((theme) => ({
-  root: {
-    display: 'flex',
-    flexDirection: 'column',
-    // marginTop: 5,
-  },
-  details: {
-    display: 'flex',
-    marginBottom: 15,
-    [theme.breakpoints.down('xs')]: {
-      flexDirection: 'column',
-    },
-  },
-  image: {
-    width: 180,
-    minWidth: 180,
-    minHeight: 145,
-    backgroundColor: theme.palette.grey['300'],
-    [theme.breakpoints.down('xs')]: {
-      width: '100%',
-    },
-  },
-  date: {
-    width: 180,
-    minWidth: 180,
-    minHeight: 145,
-    backgroundImage: `radial-gradient(circle at 50% 14em, ${theme.palette.primary.light} 0%, ${theme.palette.primary.main} 100%)`,
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    justifyContent: 'center',
-    [theme.breakpoints.down('xs')]: {
-      width: '100%',
-    },
-    padding: 0,
-    color: 'white',
-  },
-  day: {
-    fontSize: 50,
-    lineHeight: 1.3,
-  },
-  content: {
-    flex: '1 0 auto',
-    flexShrink: 1,
-    paddingTop: 10,
-    paddingBottom: '16px !important',
-    [theme.breakpoints.down('xs')]: {
-      padding: 10,
-    },
-  },
-}));
+import { useListContext } from 'react-admin';
+import { Box, CircularProgress } from '@material-ui/core';
+import CardItem from './CardItem.js';
 
 const CardsList = ({ CardComponent, link, setLoaded }) => {
-  const classes = useStyles();
   const { data, loading, loaded } = useListContext();
   if (loaded && setLoaded) {
     setLoaded();
@@ -69,32 +17,8 @@ const CardsList = ({ CardComponent, link, setLoaded }) => {
     ids
       .filter((id) => data[id])
       .map((id) => {
-        const image = data[id]['pair:depictedBy'];
-        const basePath = data[id].type.endsWith('Offer') ? '/offers' : '/projects';
         return (
-          <Link key={id} to={linkToRecord(basePath, id, link)} className={classes.root}>
-            <Card key={id} className={classes.details}>
-              {image ? (
-                <CardMedia className={classes.image} image={Array.isArray(image) ? image[0] : image} />
-              ) : (
-                <CardContent className={classes.date}>
-                  <DateField record={data[id]} variant="subtitle1" source="dc:created" locales={process.env.REACT_APP_LANG} options={{ weekday: 'long' }} />
-                  <DateField
-                    record={data[id]}
-                    variant="h4"
-                    source="dc:created"
-                    locales={process.env.REACT_APP_LANG}
-                    options={{ day: 'numeric' }}
-                    className={classes.day}
-                  />
-                  <DateField record={data[id]} variant="subtitle1" source="dc:created" locales={process.env.REACT_APP_LANG} options={{ month: 'long' }} />
-                </CardContent>
-              )}
-              <CardContent className={classes.content}>
-                <CardComponent record={data[id]} />
-              </CardContent>
-            </Card>
-          </Link>
+          <CardItem key={id} record={data[id]} CardComponent={CardComponent} />
         );
       })
   );


### PR DESCRIPTION
Je reprends ci-dessous mon commentaire envoyé en mp.  
2 avancées depuis :   
- affichage d'une icône sur les offres pour signaler que l'offre est public.
- dédoublonnage des offres lors de l'affichage de la liste.


La suppression ne fonctionne pas complètement :

J'ai une erreur 500 dans la console

J'ai bien la suppression du `foaf:agent` ici :

```
        <https://mypod.store/_acl/vincef/data/offers/642427290a2521ff6e3e3a65#Read>
                a       <http://www.w3.org/ns/auth/acl#Authorization> ;
                <http://www.w3.org/ns/auth/acl#accessTo>
                        <https://mypod.store/vincef/data/offers/642427290a2521ff6e3e3a65> ;
~~
                <http://www.w3.org/ns/auth/acl#agentClass>
                        <http://xmlns.com/foaf/0.1/Agent> ;
~~
                <http://www.w3.org/ns/auth/acl#agentGroup>
                        <https://mypod.store/_groups/vincef/data/offers/642427290a2521ff6e3e3a65/announces> ;
                <http://www.w3.org/ns/auth/acl#mode>
                        <http://www.w3.org/ns/auth/acl#Read> .
```

L'offre est toujours présente dans [data.syreen.fr](https://data.syreen.fr/) et toujours visible sur la page d'accueil.
=> Faudrait il tester la présence de foaf:agent dans les droits pour l'affichage sur la page d'accueil ?

Et j'ai noté aussi la ressource activitystreams#Announce qui reste présente dans les acl :
```
<https://mypod.store/_acl/vincef/data/activities/6424294d0a2521ff6e3e3a66#Read>
        a       <http://www.w3.org/ns/auth/acl#Authorization> ;
        <http://www.w3.org/ns/auth/acl#accessTo>
                <https://mypod.store/vincef/data/activities/6424294d0a2521ff6e3e3a66> ;
        <http://www.w3.org/ns/auth/acl#agent>
                <https://mypod.store/vincef> , <https://data.syreen.fr/actors/relay> ;
        <http://www.w3.org/ns/auth/acl#agentClass>
                <http://xmlns.com/foaf/0.1/Agent> ;
        <http://www.w3.org/ns/auth/acl#mode>
                <http://www.w3.org/ns/auth/acl#Read> .
```




